### PR TITLE
Style: Add scrollbar DashBoard Contents

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,6 +1,6 @@
 const Footer: React.FC = () => {
   return (
-    <footer className="w-full fixed h-20">
+    <footer className="w-full h-20">
       <hr />
       <span className="block text-sm text-center">
         © 2024 . All Rights Reserved.

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,13 +1,12 @@
 import { Outlet } from "react-router-dom";
-
 import Header from "./Header";
 import Footer from "./Footer";
 
 const Layout: React.FC = () => {
   return (
-    <div>
+    <div className="flex flex-col min-h-screen">
       <Header />
-      <main>
+      <main className="flex-grow max-h-[calc(100vh-128px)] overflow-auto p-4">
         <Outlet />
       </main>
       <Footer />

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -22,13 +22,12 @@ const items = [
 
 const DashBoardPage: React.FC = () => {
   return (
-    <div className="p-4">
+    <div className="p-4 h-full">
       <div className="grid grid-cols-4 gap-4">
         {items.map((item) => (
           <FigmaItem key={item.id} {...item} />
         ))}
       </div>
-      <button>팀 초대하기</button>
     </div>
   );
 };

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,6 @@
 import Layout from "./components/Layout";
 import InitialPage from "./pages/InitialPage";
-import DashboardPage from "./pages/DashBoardPage";
+import DashboardPage from "./pages/DashboardPage";
 
 interface RouteConfig {
   path?: string;


### PR DESCRIPTION
### FigDiff

## [DashBoardPage](https://www.notion.so/FigDiff-cd08255c47ba43f5bccb6f4579f0d3fa?p=095885f08dfd471da84531d2916b2662&pm=s)

## Todo

- [x] 로고 이미지가 포함된 Header 가 보여져야 합니다.
- [x] Footer 가 보여져야 합니다.
- [x] 피그마 프로젝트들이 카드 형식으로 보여져야 합니다. 

## Description
Layout 안에 main 부분 (DashBoardPage)의 items 갯수가 많아질 때 마다 전체 화면 스크롤이 늘어가는 걸 main 부분만 스크롤 가능하게끔 수정하였습니다.

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)

https://github.com/user-attachments/assets/a60ae270-cd8b-4805-8f76-f04648c7bd34