### PR TITLE
Feat/History Page

### DIFF
--- a/src/assets/mockData.json
+++ b/src/assets/mockData.json
@@ -1,0 +1,67 @@
+{
+  "userId": "939132111231231231231232312",
+  "pageNames": [
+    {
+      "pageName": "client.figci.net",
+      "tabUrls": [
+        {
+          "urlName": "/hello",
+          "history": [
+            {
+              "historyName": "2024. 7. 29. 오후 9:35:06",
+              "imageUrls": [
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506245-8443869c-ab5f-4897-b30c-7bd7d39f12cd-icons8-github-120.png",
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506246-0ce913d8-8eaa-4f0e-8ba4-21474ad28fce-icons8-phone-90.png"
+              ],
+              "date": "2024. 7. 29. 오후 9:34:41"
+            }
+          ]
+        },
+        {
+          "urlName": "/bye",
+          "history": [
+            {
+              "historyName": "2024. 7. 30. 오전 10:35:06",
+              "imageUrls": [
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506245-8443869c-ab5f-4897-b30c-7bd7d39f12cd-icons8-github-120.png",
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506246-0ce913d8-8eaa-4f0e-8ba4-21474ad28fce-icons8-phone-90.png"
+              ],
+              "date": "2024. 7. 29. 오후 9:34:41"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "pageName": "naver.com",
+      "tabUrls": [
+        {
+          "urlName": "/main",
+          "history": [
+            {
+              "historyName": "2024. 7. 29. 오후 9:35:06",
+              "imageUrls": [
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506245-8443869c-ab5f-4897-b30c-7bd7d39f12cd-icons8-github-120.png",
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506246-0ce913d8-8eaa-4f0e-8ba4-21474ad28fce-icons8-phone-90.png"
+              ],
+              "date": "2024. 7. 29. 오후 9:34:41"
+            }
+          ]
+        },
+        {
+          "urlName": "/profile",
+          "history": [
+            {
+              "historyName": "2024. 7. 30. 오전 10:35:06",
+              "imageUrls": [
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506245-8443869c-ab5f-4897-b30c-7bd7d39f12cd-icons8-github-120.png",
+                "https://figdiff.s3.ap-northeast-2.amazonaws.com/1722256506246-0ce913d8-8eaa-4f0e-8ba4-21474ad28fce-icons8-phone-90.png"
+              ],
+              "date": "2024. 7. 29. 오후 9:34:41"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/FigmaItem.tsx
+++ b/src/components/FigmaItem.tsx
@@ -2,10 +2,10 @@ import { useNavigate } from "react-router-dom";
 
 interface FigmaItemProps {
   pageName: string;
-  urlName: string[];
+  tabCount: number;
 }
 
-const FigmaItem: React.FC<FigmaItemProps> = ({ pageName, urlName }) => {
+const FigmaItem: React.FC<FigmaItemProps> = ({ pageName, tabCount }) => {
   const navigate = useNavigate();
 
   const handleItemClick = () => {
@@ -18,11 +18,7 @@ const FigmaItem: React.FC<FigmaItemProps> = ({ pageName, urlName }) => {
       onClick={handleItemClick}
     >
       <h2 className="font-bold text-xl mb-2">{pageName}</h2>
-      <ul>
-        {urlName.map((url, index) => (
-          <li key={index}>{url}</li>
-        ))}
-      </ul>
+      <p>저장된 리소스: {tabCount}개</p>
     </div>
   );
 };

--- a/src/components/FigmaItem.tsx
+++ b/src/components/FigmaItem.tsx
@@ -1,15 +1,28 @@
-import React from "react";
+import { useNavigate } from "react-router-dom";
 
 interface FigmaItemProps {
-  title: string;
-  description: string;
+  pageName: string;
+  urlName: string[];
 }
 
-const FigmaItem: React.FC<FigmaItemProps> = ({ title, description }) => {
+const FigmaItem: React.FC<FigmaItemProps> = ({ pageName, urlName }) => {
+  const navigate = useNavigate();
+
+  const handleItemClick = () => {
+    navigate(`/history/${pageName}`);
+  };
+
   return (
-    <div className="border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow duration-200">
-      <h2 className="font-bold text-xl mb-2">{title}</h2>
-      <p>{description}</p>
+    <div
+      className="border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow duration-200"
+      onClick={handleItemClick}
+    >
+      <h2 className="font-bold text-xl mb-2">{pageName}</h2>
+      <ul>
+        {urlName.map((url, index) => (
+          <li key={index}>{url}</li>
+        ))}
+      </ul>
     </div>
   );
 };

--- a/src/components/HistoryCard.tsx
+++ b/src/components/HistoryCard.tsx
@@ -1,0 +1,18 @@
+interface HistoryCardProps {
+  createdAt: string;
+  description: string;
+}
+
+const HistoryCard: React.FC<HistoryCardProps> = ({
+  createdAt,
+  description,
+}) => {
+  return (
+    <div className="bg-white p-4 shadow rounded-lg m-2 flex-1 max-w-xs">
+      <h3 className="font-semibold">{createdAt}</h3>
+      <p>{description}</p>
+    </div>
+  );
+};
+
+export default HistoryCard;

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -2,7 +2,7 @@ import FigDiffLogo from "/logo.png";
 
 const Header: React.FC = () => {
   return (
-    <header className="flex items-center justify-center h-16 font-bold border-b border-gray-300">
+    <header className="flex items-center justify-start h-16 font-bold border-b border-gray-300 pl-4">
       <img src={FigDiffLogo} alt="FigDiff Logo" className="h-10 mr-3" />
       <h1>FigDiff</h1>
     </header>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from "react-router-dom";
+
 import Header from "./Header";
 import Footer from "./Footer";
 

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -14,7 +14,7 @@ const DashBoardPage: React.FC = () => {
           <FigmaItem
             key={page.pageName}
             pageName={page.pageName}
-            urlName={page.tabUrls.map((tab) => tab.urlName)}
+            tabCount={page.tabUrls.length}
           />
         ))}
       </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,31 +1,21 @@
-import React from "react";
 import FigmaItem from "../components/FigmaItem";
-
-const items = [
-  { id: 1, title: "Item 1", description: "Description 1" },
-  { id: 2, title: "Item 2", description: "Description 2" },
-  { id: 3, title: "Item 3", description: "Description 3" },
-  { id: 4, title: "Item 4", description: "Description 4" },
-  { id: 5, title: "Item 5", description: "Description 5" },
-  { id: 6, title: "Item 6", description: "Description 6" },
-  { id: 7, title: "Item 7", description: "Description 7" },
-  { id: 8, title: "Item 8", description: "Description 8" },
-  { id: 9, title: "Item 9", description: "Description 9" },
-  { id: 10, title: "Item 10", description: "Description 10" },
-  { id: 11, title: "Item 11", description: "Description 11" },
-  { id: 12, title: "Item 12", description: "Description 12" },
-  { id: 13, title: "Item 13", description: "Description 13" },
-  { id: 14, title: "Item 14", description: "Description 14" },
-  { id: 15, title: "Item 15", description: "Description 15" },
-  { id: 16, title: "Item 16", description: "Description 16" },
-];
+import data from "../assets/mockData.json";
 
 const DashBoardPage: React.FC = () => {
   return (
     <div className="p-4 h-full">
+      <div className="flex justify-end">
+        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+          팀 초대하기
+        </button>
+      </div>
       <div className="grid grid-cols-4 gap-4">
-        {items.map((item) => (
-          <FigmaItem key={item.id} {...item} />
+        {data.pageNames.map((page) => (
+          <FigmaItem
+            key={page.pageName}
+            pageName={page.pageName}
+            urlName={page.tabUrls.map((tab) => tab.urlName)}
+          />
         ))}
       </div>
     </div>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+
+import HistoryCard from "../components/HistoryCard";
+import data from "../assets/mockData.json";
+
+interface TabUrl {
+  urlName: string;
+  history: { date: string; historyName: string }[];
+}
+
+interface PageData {
+  pageName: string;
+  tabUrls: TabUrl[];
+}
+
+const HistoryPage: React.FC = () => {
+  const { pageName } = useParams<{ pageName: string }>();
+  const pageData = data.pageNames.find(
+    (page) => page.pageName === pageName,
+  ) as PageData;
+  const [selectedTab, setSelectedTab] = useState<TabUrl | null>(null);
+
+  return (
+    <div className="flex w-full h-full">
+      <div className="w-1/4 border-r border-gray-300 p-4">
+        <h2 className="text-lg font-semibold mb-4">{pageData?.pageName}</h2>
+        <ul>
+          {pageData?.tabUrls.map((tab, index) => (
+            <li
+              key={index}
+              className="cursor-pointer hover:bg-gray-200 p-2"
+              onClick={() => setSelectedTab(tab)}
+            >
+              {tab.urlName}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="w-3/4 p-4">
+        {selectedTab ? (
+          <>
+            <h3 className="text-lg font-semibold mb-4">
+              History for {selectedTab.urlName}
+            </h3>
+            <div className="flex flex-wrap">
+              {selectedTab.history.map((history, index) => (
+                <HistoryCard
+                  key={index}
+                  createdAt={history.date}
+                  description={history.historyName}
+                />
+              ))}
+            </div>
+          </>
+        ) : (
+          <p className="text-gray-500">Select a URL to view its history.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HistoryPage;

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -22,8 +22,8 @@ const HistoryPage: React.FC = () => {
   const [selectedTab, setSelectedTab] = useState<TabUrl | null>(null);
 
   return (
-    <div className="flex w-full h-full">
-      <div className="w-1/4 border-r border-gray-300 p-4">
+    <div className="flex w-full min-h-screen">
+      <div className="w-1/4 border-r border-gray-300">
         <h2 className="text-lg font-semibold mb-4">{pageData?.pageName}</h2>
         <ul>
           {pageData?.tabUrls.map((tab, index) => (

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,7 @@
 import Layout from "./components/Layout";
 import InitialPage from "./pages/InitialPage";
-import DashboardPage from "./pages/DashboardPage";
+import DashBoardPage from "./pages/DashBoardPage";
+import HistoryPage from "./pages/HistoryPage";
 
 interface RouteConfig {
   path?: string;
@@ -13,7 +14,8 @@ export const routes: RouteConfig[] = [
     element: <Layout />,
     children: [
       { path: "/", element: <InitialPage /> },
-      { path: "/dash", element: <DashboardPage /> },
+      { path: "/dash", element: <DashBoardPage /> },
+      { path: "/history/:pageName", element: <HistoryPage /> },
     ],
   },
 ];


### PR DESCRIPTION
### FigDiff

## [History Page](https://www.notion.so/818dfe86e144449aa6c78f0edb9d3cb3?v=7c1403a073984e0b87bf199bd4c1c96a&p=6fad27e2fc9f4fb295acd66985ea0d94&pm=s)

## Todo

- [x] DashBoard 페이지에서 클릭한 사이트에 대한 히스토리 내역이 보여져야 합니다.
- [x] 페이지 좌측에 해당 히스토리에 대한 목록이 나열되어야 합니다.
- [x] 목록의 각 요소를 클릭하면 해당 요소의 스크린샷 기록 목록이 화면 우측에 보여져야 합니다.

## Description

- 사용자 이용 내역을 확인할 수 있는 History Page 를 구성했습니다.

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
<img width="1431" alt="스크린샷 2024-07-30 오후 4 57 16" src="https://github.com/user-attachments/assets/ba0a9e93-f55c-43c1-b141-13f167940c92">

<img width="1434" alt="스크린샷 2024-07-30 오후 4 57 38" src="https://github.com/user-attachments/assets/95f8ed45-947e-460b-ad02-4f7b0567d82d">

<img width="1435" alt="스크린샷 2024-07-30 오후 4 57 51" src="https://github.com/user-attachments/assets/583ca82e-bde1-408d-b80b-8a9cca795499">