### PR TITLE
Feat: Add History Delete Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist-ssr
 !.vscode/extensions.json
 .idea
 .DS_Store
+.env
 *.suo
 *.ntvs*
 *.njsproj

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-project",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.2.1",
@@ -1818,6 +1819,11 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
@@ -1877,6 +1883,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2081,6 +2097,17 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2278,6 +2305,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/didyoumean": {
@@ -3140,6 +3175,25 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -3163,6 +3217,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -4185,6 +4252,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
@@ -4797,6 +4883,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint-staged": "lint-staged"
   },
   "dependencies": {
+    "axios": "^1.7.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -30,8 +30,8 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({
     <>
       <button
         className={`absolute top-0 right-0 m-0.5 p-0.5 bg-gray-100 hover:bg-gray-300 rounded-full ${className}`}
-        onClick={(e) => {
-          e.stopPropagation();
+        onClick={(event) => {
+          event.stopPropagation();
           handleToggleModal();
         }}
       >

--- a/src/components/DeleteButton.tsx
+++ b/src/components/DeleteButton.tsx
@@ -4,11 +4,22 @@ import { IoIosClose } from "react-icons/io";
 import DeleteModal from "./DeleteModal";
 
 interface DeleteButtonProps {
+  userId: string;
   pageName: string;
+  tabUrlName: string;
+  historyName: string;
   className: string;
+  onDelete: () => void;
 }
 
-const DeleteButton: React.FC<DeleteButtonProps> = ({ pageName, className }) => {
+const DeleteButton: React.FC<DeleteButtonProps> = ({
+  userId,
+  pageName,
+  tabUrlName,
+  historyName,
+  className,
+  onDelete,
+}) => {
   const [showModal, setShowModal] = useState(false);
 
   const handleToggleModal = () => {
@@ -28,12 +39,14 @@ const DeleteButton: React.FC<DeleteButtonProps> = ({ pageName, className }) => {
       </button>
       {showModal && (
         <DeleteModal
+          userId={userId}
+          pageName={pageName}
+          tabUrlName={tabUrlName}
+          historyName={historyName}
           isOpen={showModal}
           onCancel={handleToggleModal}
-          onDelete={() => {
-            console.log(`${pageName} 페이지 삭제 처리`);
-            handleToggleModal();
-          }}
+          onDelete={onDelete}
+          onToggle={handleToggleModal}
         />
       )}
     </>

--- a/src/components/DeleteModal.tsx
+++ b/src/components/DeleteModal.tsx
@@ -1,13 +1,28 @@
 interface DeleteModalProps {
+  userId: string;
+  pageName: string;
+  tabUrlName: string;
+  historyName: string;
   isOpen: boolean;
   onCancel: () => void;
-  onDelete: () => void;
+  onDelete: (
+    userId: string,
+    pageName: string,
+    tabUrlName: string,
+    historyName: string,
+  ) => void;
+  onToggle: () => void;
 }
 
 const DeleteModal: React.FC<DeleteModalProps> = ({
+  userId,
+  pageName,
+  tabUrlName,
+  historyName,
   isOpen,
   onCancel,
   onDelete,
+  onToggle,
 }) => {
   if (!isOpen) return null;
 
@@ -16,9 +31,17 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
     onCancel();
   };
 
-  const handleDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleDelete = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    userId: string,
+    pageName: string,
+    tabUrlName: string,
+    historyName: string,
+  ) => {
     event.stopPropagation();
-    onDelete();
+
+    onDelete(userId, pageName, tabUrlName, historyName);
+    onToggle();
   };
 
   const handleOverlayClick = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -47,7 +70,9 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
             취소
           </button>
           <button
-            onClick={handleDelete}
+            onClick={(ev) =>
+              handleDelete(ev, userId, pageName, tabUrlName, historyName)
+            }
             className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
           >
             삭제

--- a/src/components/DeleteModal.tsx
+++ b/src/components/DeleteModal.tsx
@@ -56,7 +56,7 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
     >
       <div
         className="bg-white p-4 rounded-lg shadow-lg"
-        onClick={(e) => e.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
       >
         <h2 className="text-lg font-bold mb-4">
           해당 콘텐츠를 삭제하시겠습니까?
@@ -70,8 +70,8 @@ const DeleteModal: React.FC<DeleteModalProps> = ({
             취소
           </button>
           <button
-            onClick={(ev) =>
-              handleDelete(ev, userId, pageName, tabUrlName, historyName)
+            onClick={(event) =>
+              handleDelete(event, userId, pageName, tabUrlName, historyName)
             }
             className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
           >

--- a/src/components/FigmaItem.tsx
+++ b/src/components/FigmaItem.tsx
@@ -1,17 +1,30 @@
+import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import DeleteButton from "./DeleteButton";
 
 interface FigmaItemProps {
+  userId: string;
   pageName: string;
   tabCount: number;
+  onDelete: (pageName: string) => void;
 }
 
-const FigmaItem: React.FC<FigmaItemProps> = ({ pageName, tabCount }) => {
+const FigmaItem: React.FC<FigmaItemProps> = ({
+  userId,
+  pageName,
+  tabCount,
+  onDelete,
+}) => {
   const navigate = useNavigate();
 
   const handleItemClick = () => {
-    navigate(`/history/${pageName}`);
+    navigate(`/dash/${userId}/history/${pageName}`);
+  };
+
+  const handleDeleteClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete(pageName);
   };
 
   return (
@@ -25,6 +38,12 @@ const FigmaItem: React.FC<FigmaItemProps> = ({ pageName, tabCount }) => {
       />
       <h2 className="font-bold text-xl mb-2">{pageName}</h2>
       <p>저장된 리소스: {tabCount}개</p>
+      <button
+        onClick={handleDeleteClick}
+        className="absolute top-2 right-2 bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded"
+      >
+        X
+      </button>
     </div>
   );
 };

--- a/src/components/FigmaItem.tsx
+++ b/src/components/FigmaItem.tsx
@@ -22,8 +22,8 @@ const FigmaItem: React.FC<FigmaItemProps> = ({
     navigate(`/dash/${userId}/history/${pageName}`);
   };
 
-  const handleDeleteClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleDeleteClick = (event: React.MouseEvent) => {
+    event.stopPropagation();
     onDelete(pageName);
   };
 

--- a/src/components/HistoryCard.tsx
+++ b/src/components/HistoryCard.tsx
@@ -33,9 +33,6 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
           <h3 className="font-semibold">{createdAt}</h3>
           <p>{historyName}</p>
         </div>
-        {/* <button onClick={onDelete} className="text-red-500 hover:text-red-700">
-          x
-        </button> */}
       </div>
     </div>
   );

--- a/src/components/HistoryCard.tsx
+++ b/src/components/HistoryCard.tsx
@@ -1,19 +1,42 @@
+import React from "react";
 import DeleteButton from "./DeleteButton";
 
 interface HistoryCardProps {
+  userId: string;
+  pageName: string;
+  tabUrlName: string;
+  historyName: string;
   createdAt: string;
-  description: string;
+  onDelete: () => void;
 }
 
 const HistoryCard: React.FC<HistoryCardProps> = ({
+  userId,
+  pageName,
+  tabUrlName,
+  historyName,
   createdAt,
-  description,
+  onDelete,
 }) => {
   return (
     <div className="relative bg-white p-4 shadow rounded-lg m-2 flex-1 max-w-xs">
-      <DeleteButton pageName={description} className="absolute top-0 right-0" />
-      <h3 className="font-semibold">{createdAt}</h3>
-      <p>{description}</p>
+      <div className="flex justify-between items-center">
+        <div>
+          <DeleteButton
+            userId={userId}
+            pageName={pageName}
+            tabUrlName={tabUrlName}
+            historyName={historyName}
+            className="absolute top-0 right-0"
+            onDelete={onDelete}
+          />
+          <h3 className="font-semibold">{createdAt}</h3>
+          <p>{historyName}</p>
+        </div>
+        {/* <button onClick={onDelete} className="text-red-500 hover:text-red-700">
+          x
+        </button> */}
+      </div>
     </div>
   );
 };

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,14 +1,15 @@
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { IoMdHome } from "react-icons/io";
 
 import FigDiffLogo from "/logo.png";
 
 const Header: React.FC = () => {
   const navigate = useNavigate();
+  const { userId } = useParams();
   const location = useLocation();
 
   const handleHomeClick = () => {
-    navigate("/dash");
+    navigate(`/dash/${userId}`);
   };
 
   const isInitialPage = location.pathname === "/";

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,7 +1,54 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
 import FigmaItem from "../components/FigmaItem";
-import data from "../assets/mockData.json";
+import { useParams } from "react-router-dom";
 
 const DashBoardPage: React.FC = () => {
+  const [data, setData] = useState(null);
+  const { userId } = useParams();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          `${import.meta.env.VITE_SERVER_URL}/${userId}`,
+        );
+
+        setData(response.data.userData);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const handleDeletePage = async (pageName: string) => {
+    try {
+      await axios.patch(`${import.meta.env.VITE_SERVER_URL}/delete-page`, {
+        userId,
+        pageName,
+      });
+
+      setData((prevData) => {
+        if (!prevData) return null;
+
+        return {
+          ...prevData,
+          pageNames: prevData.pageNames.filter(
+            (page) => page.pageName !== pageName,
+          ),
+        };
+      });
+    } catch (error) {
+      console.error("Error deleting page:", error);
+    }
+  };
+
+  if (!data) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <div className="p-4 h-full">
       <div className="flex justify-end">
@@ -13,8 +60,10 @@ const DashBoardPage: React.FC = () => {
         {data.pageNames.map((page) => (
           <FigmaItem
             key={page.pageName}
+            userId={userId as string}
             pageName={page.pageName}
             tabCount={page.tabUrls.length}
+            onDelete={handleDeletePage}
           />
         ))}
       </div>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -141,25 +141,12 @@ const HistoryPage: React.FC = () => {
         <h2 className="text-lg font-semibold mb-4">{pageData?.pageName}</h2>
         <ul>
           {pageData?.tabUrls.map((tab, index) => (
-            // <li
-            //   key={index}
-            //   className="relative cursor-pointer hover:bg-gray-200 p-2 flex justify-between items-center"
-            // >
-            //   <span onClick={() => setSelectedTab(tab)}>{tab.tabUrlName}</span>
-            //   <button
-            //     className="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded"
-            //     onClick={() => handleDeleteTabUrl(tab.tabUrlName)}
-            //   >
-            //     X
-            //   </button>
-            // </li>
             <li
               key={index}
               className="relative cursor-pointer hover:bg-gray-200 p-2"
             >
               <span onClick={() => setSelectedTab(tab)}>{tab.tabUrlName}</span>
               <DeleteButton
-                // pageName={tab.tabUrlName}
                 userId={userId as string}
                 pageName={pageName as string}
                 tabUrlName={tab.tabUrlName}
@@ -182,7 +169,6 @@ const HistoryPage: React.FC = () => {
                 <HistoryCard
                   key={index}
                   createdAt={history.date}
-                  // description={history.historyName}
                   userId={userId as string}
                   pageName={pageName as string}
                   tabUrlName={selectedTab.tabUrlName}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,12 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import HistoryCard from "../components/HistoryCard";
 import DeleteButton from "../components/DeleteButton";
-import data from "../assets/mockData.json";
+import axios from "axios";
 
 interface TabUrl {
-  urlName: string;
+  tabUrlName: string;
   history: { date: string; historyName: string }[];
 }
 
@@ -16,11 +16,124 @@ interface PageData {
 }
 
 const HistoryPage: React.FC = () => {
-  const { pageName } = useParams<{ pageName: string }>();
+  const [data, setData] = useState(null);
+  const { pageName, userId } = useParams<{
+    pageName: string;
+    userId: string;
+  }>();
+  const [selectedTab, setSelectedTab] = useState<TabUrl | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          `${import.meta.env.VITE_SERVER_URL}/${userId}`,
+        );
+
+        setData(response.data.userData);
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  if (!data) {
+    return <div>Loading...</div>;
+  }
+
   const pageData = data.pageNames.find(
     (page) => page.pageName === pageName,
   ) as PageData;
-  const [selectedTab, setSelectedTab] = useState<TabUrl | null>(null);
+
+  const handleDeleteTabUrl = async (
+    userId: string,
+    pageName: string,
+    tabUrlName: string,
+    historyName: string,
+  ) => {
+    try {
+      await axios.patch(`${import.meta.env.VITE_SERVER_URL}/delete-taburl`, {
+        userId,
+        pageName,
+        tabUrlName,
+        historyName,
+      });
+
+      setData((prevData) => {
+        if (!prevData) return null;
+
+        return {
+          ...prevData,
+          pageNames: prevData.pageNames.map((page) => {
+            if (page.pageName === pageName) {
+              return {
+                ...page,
+                tabUrls: page.tabUrls.filter(
+                  (tab) => tab.tabUrlName !== tabUrlName,
+                ),
+              };
+            }
+            return page;
+          }),
+        };
+      });
+
+      if (selectedTab?.tabUrlName === tabUrlName) {
+        setSelectedTab(null);
+      }
+    } catch (error) {
+      console.error("Error deleting tab URL:", error);
+    }
+  };
+
+  const handleDeleteHistory = async (
+    userId: string,
+    pageName: string,
+    tabUrlName: string,
+    historyName: string,
+  ) => {
+    if (!selectedTab) return;
+
+    try {
+      await axios.patch(`${import.meta.env.VITE_SERVER_URL}/delete-history`, {
+        userId,
+        pageName,
+        tabUrlName,
+        historyName,
+      });
+
+      setData((prevData) => {
+        if (!prevData) return null;
+
+        return {
+          ...prevData,
+          pageNames: prevData.pageNames.map((page) => {
+            if (page.pageName === pageName) {
+              return {
+                ...page,
+                tabUrls: page.tabUrls.map((tab) => {
+                  if (tab.tabUrlName === selectedTab.tabUrlName) {
+                    return {
+                      ...tab,
+                      history: tab.history.filter(
+                        (history) => history.historyName !== historyName,
+                      ),
+                    };
+                  }
+                  return tab;
+                }),
+              };
+            }
+            return page;
+          }),
+        };
+      });
+    } catch (error) {
+      console.error("히스토리 삭제 오류:", error);
+    }
+  };
 
   return (
     <div className="flex w-full min-h-screen">
@@ -28,13 +141,32 @@ const HistoryPage: React.FC = () => {
         <h2 className="text-lg font-semibold mb-4">{pageData?.pageName}</h2>
         <ul>
           {pageData?.tabUrls.map((tab, index) => (
+            // <li
+            //   key={index}
+            //   className="relative cursor-pointer hover:bg-gray-200 p-2 flex justify-between items-center"
+            // >
+            //   <span onClick={() => setSelectedTab(tab)}>{tab.tabUrlName}</span>
+            //   <button
+            //     className="bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded"
+            //     onClick={() => handleDeleteTabUrl(tab.tabUrlName)}
+            //   >
+            //     X
+            //   </button>
+            // </li>
             <li
               key={index}
               className="relative cursor-pointer hover:bg-gray-200 p-2"
-              onClick={() => setSelectedTab(tab)}
             >
-              <span>{tab.urlName}</span>
-              <DeleteButton pageName={tab.urlName} className="top-2 right-0" />
+              <span onClick={() => setSelectedTab(tab)}>{tab.tabUrlName}</span>
+              <DeleteButton
+                // pageName={tab.tabUrlName}
+                userId={userId as string}
+                pageName={pageName as string}
+                tabUrlName={tab.tabUrlName}
+                historyName="void"
+                className="top-2 right-0"
+                onDelete={handleDeleteTabUrl}
+              />
             </li>
           ))}
         </ul>
@@ -43,14 +175,19 @@ const HistoryPage: React.FC = () => {
         {selectedTab ? (
           <>
             <h3 className="text-lg font-semibold mb-4">
-              History for {selectedTab.urlName}
+              History for {selectedTab.tabUrlName}
             </h3>
             <div className="flex flex-wrap">
               {selectedTab.history.map((history, index) => (
                 <HistoryCard
                   key={index}
                   createdAt={history.date}
-                  description={history.historyName}
+                  // description={history.historyName}
+                  userId={userId as string}
+                  pageName={pageName as string}
+                  tabUrlName={selectedTab.tabUrlName}
+                  historyName={history.historyName}
+                  onDelete={handleDeleteHistory}
                 />
               ))}
             </div>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -14,8 +14,8 @@ export const routes: RouteConfig[] = [
     element: <Layout />,
     children: [
       { path: "/", element: <InitialPage /> },
-      { path: "/dash", element: <DashBoardPage /> },
-      { path: "/history/:pageName", element: <HistoryPage /> },
+      { path: "/dash/:userId", element: <DashBoardPage /> },
+      { path: "/dash/:userId/history/:pageName", element: <HistoryPage /> },
     ],
   },
 ];


### PR DESCRIPTION
### FigDiff

## [[Web] Delete History Data](https://www.notion.so/818dfe86e144449aa6c78f0edb9d3cb3?v=7c1403a073984e0b87bf199bd4c1c96a&p=47b9c5e6b4664ec28cdbb6d35cc18e8b&pm=s)

## Todo

- [x] DashBoardPage에서 삭제 버튼을 누르면 figmaProject가 하나 삭제되어야 합니다.
- [x] HistoryPage에서 사이트 이름 삭제 버튼을 누르면 figmaSite가 하나 삭제되어야 합니다.
- [x] HistoryPage에서 history 각각의 삭제 버튼을 누르면 하나의 data가 삭제되어야 합니다.

## Description

- history 관련 삭제버튼을 누르면 서버로 삭제 요청을 보내고 데이터를 삭제하는 작업을 하였습니다.

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
