### PR TITLE
Fix: Add History Delete Function

### DIFF
--- a/src/components/FigmaItem.tsx
+++ b/src/components/FigmaItem.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-
-import DeleteButton from "./DeleteButton";
+import DeleteModal from "../components/DeleteModal";
+import { IoIosClose } from "react-icons/io";
 
 interface FigmaItemProps {
   userId: string;
@@ -17,6 +17,7 @@ const FigmaItem: React.FC<FigmaItemProps> = ({
   onDelete,
 }) => {
   const navigate = useNavigate();
+  const [showModal, setShowModal] = useState(false);
 
   const handleItemClick = () => {
     navigate(`/dash/${userId}/history/${pageName}`);
@@ -24,7 +25,16 @@ const FigmaItem: React.FC<FigmaItemProps> = ({
 
   const handleDeleteClick = (event: React.MouseEvent) => {
     event.stopPropagation();
+    setShowModal(true);
+  };
+
+  const handleToggleModal = () => {
+    setShowModal(!showModal);
+  };
+
+  const handleConfirmDelete = () => {
     onDelete(pageName);
+    setShowModal(false);
   };
 
   return (
@@ -32,18 +42,26 @@ const FigmaItem: React.FC<FigmaItemProps> = ({
       className="border rounded-lg p-4 shadow-sm hover:shadow-md transition-shadow duration-200 relative"
       onClick={handleItemClick}
     >
-      <DeleteButton
-        pageName={pageName}
-        className="absolute top-0 right-0 m-0.5 p-0.5"
-      />
       <h2 className="font-bold text-xl mb-2">{pageName}</h2>
       <p>저장된 리소스: {tabCount}개</p>
       <button
         onClick={handleDeleteClick}
-        className="absolute top-2 right-2 bg-red-500 hover:bg-red-700 text-white font-bold py-1 px-2 rounded"
+        className="absolute top-2 right-2 bg-red-500 hover:bg-red-700 text-white text-2xl font-bold py-1 px-2 rounded"
       >
-        X
+        <IoIosClose />
       </button>
+      {showModal && (
+        <DeleteModal
+          userId={userId}
+          pageName={pageName}
+          tabUrlName=""
+          historyName=""
+          isOpen={showModal}
+          onCancel={handleToggleModal}
+          onDelete={handleConfirmDelete}
+          onToggle={handleToggleModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/HistoryCard.tsx
+++ b/src/components/HistoryCard.tsx
@@ -31,7 +31,6 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
             onDelete={onDelete}
           />
           <h3 className="font-semibold">{createdAt}</h3>
-          <p>{historyName}</p>
         </div>
       </div>
     </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -3,8 +3,17 @@ import axios from "axios";
 import FigmaItem from "../components/FigmaItem";
 import { useParams } from "react-router-dom";
 
+interface PageData {
+  pageName: string;
+  tabUrls: string[];
+}
+
+interface UserData {
+  pageNames: PageData[];
+}
+
 const DashBoardPage: React.FC = () => {
-  const [data, setData] = useState(null);
+  const [data, setData] = useState<UserData | null>(null);
   const { userId } = useParams();
 
   useEffect(() => {
@@ -51,11 +60,6 @@ const DashBoardPage: React.FC = () => {
 
   return (
     <div className="p-4 h-full">
-      <div className="flex justify-end">
-        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-          팀 초대하기
-        </button>
-      </div>
       <div className="grid grid-cols-4 gap-4">
         {data.pageNames.map((page) => (
           <FigmaItem

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -43,7 +43,7 @@ const HistoryPage: React.FC = () => {
       }
     };
     fetchData();
-  }, [userId]);
+  }, []);
 
   if (!data) {
     return <div>Loading...</div>;

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,13 +1,17 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-
 import HistoryCard from "../components/HistoryCard";
 import DeleteButton from "../components/DeleteButton";
 import axios from "axios";
 
+interface History {
+  date: string;
+  historyName: string;
+}
+
 interface TabUrl {
   tabUrlName: string;
-  history: { date: string; historyName: string }[];
+  history: History[];
 }
 
 interface PageData {
@@ -15,8 +19,12 @@ interface PageData {
   tabUrls: TabUrl[];
 }
 
+interface UserData {
+  pageNames: PageData[];
+}
+
 const HistoryPage: React.FC = () => {
-  const [data, setData] = useState(null);
+  const [data, setData] = useState<UserData | null>(null);
   const { pageName, userId } = useParams<{
     pageName: string;
     userId: string;
@@ -29,22 +37,20 @@ const HistoryPage: React.FC = () => {
         const response = await axios.get(
           `${import.meta.env.VITE_SERVER_URL}/${userId}`,
         );
-
         setData(response.data.userData);
       } catch (error) {
         console.error("Error fetching data:", error);
       }
     };
-
     fetchData();
-  }, []);
+  }, [userId]);
 
   if (!data) {
     return <div>Loading...</div>;
   }
 
   const pageData = data.pageNames.find(
-    (page) => page.pageName === pageName,
+    (page: PageData) => page.pageName === pageName,
   ) as PageData;
 
   const handleDeleteTabUrl = async (
@@ -64,19 +70,21 @@ const HistoryPage: React.FC = () => {
       setData((prevData) => {
         if (!prevData) return null;
 
+        const updatedPageNames = prevData.pageNames.map((page) => {
+          if (page.pageName === pageName) {
+            return {
+              ...page,
+              tabUrls: page.tabUrls.filter(
+                (tab) => tab.tabUrlName !== tabUrlName,
+              ),
+            };
+          }
+          return page;
+        });
+
         return {
           ...prevData,
-          pageNames: prevData.pageNames.map((page) => {
-            if (page.pageName === pageName) {
-              return {
-                ...page,
-                tabUrls: page.tabUrls.filter(
-                  (tab) => tab.tabUrlName !== tabUrlName,
-                ),
-              };
-            }
-            return page;
-          }),
+          pageNames: updatedPageNames,
         };
       });
 
@@ -107,31 +115,44 @@ const HistoryPage: React.FC = () => {
       setData((prevData) => {
         if (!prevData) return null;
 
+        const updatedPageNames = prevData.pageNames.map((page) => {
+          if (page.pageName === pageName) {
+            return {
+              ...page,
+              tabUrls: page.tabUrls.map((tab) => {
+                if (tab.tabUrlName === tabUrlName) {
+                  return {
+                    ...tab,
+                    history: tab.history.filter(
+                      (history) => history.historyName !== historyName,
+                    ),
+                  };
+                }
+                return tab;
+              }),
+            };
+          }
+          return page;
+        });
+
         return {
           ...prevData,
-          pageNames: prevData.pageNames.map((page) => {
-            if (page.pageName === pageName) {
-              return {
-                ...page,
-                tabUrls: page.tabUrls.map((tab) => {
-                  if (tab.tabUrlName === selectedTab.tabUrlName) {
-                    return {
-                      ...tab,
-                      history: tab.history.filter(
-                        (history) => history.historyName !== historyName,
-                      ),
-                    };
-                  }
-                  return tab;
-                }),
-              };
-            }
-            return page;
-          }),
+          pageNames: updatedPageNames,
+        };
+      });
+
+      setSelectedTab((prevTab) => {
+        if (!prevTab) return null;
+
+        return {
+          ...prevTab,
+          history: prevTab.history.filter(
+            (history) => history.historyName !== historyName,
+          ),
         };
       });
     } catch (error) {
-      console.error("히스토리 삭제 오류:", error);
+      console.error("Error deleting history:", error);
     }
   };
 
@@ -143,16 +164,24 @@ const HistoryPage: React.FC = () => {
           {pageData?.tabUrls.map((tab, index) => (
             <li
               key={index}
+              onClick={() => setSelectedTab(tab)}
               className="relative cursor-pointer hover:bg-gray-200 p-2"
             >
-              <span onClick={() => setSelectedTab(tab)}>{tab.tabUrlName}</span>
+              <span>{tab.tabUrlName}</span>
               <DeleteButton
                 userId={userId as string}
                 pageName={pageName as string}
                 tabUrlName={tab.tabUrlName}
                 historyName="void"
                 className="top-2 right-0"
-                onDelete={handleDeleteTabUrl}
+                onDelete={() =>
+                  handleDeleteTabUrl(
+                    userId as string,
+                    pageName as string,
+                    tab.tabUrlName,
+                    "void",
+                  )
+                }
               />
             </li>
           ))}
@@ -173,7 +202,14 @@ const HistoryPage: React.FC = () => {
                   pageName={pageName as string}
                   tabUrlName={selectedTab.tabUrlName}
                   historyName={history.historyName}
-                  onDelete={handleDeleteHistory}
+                  onDelete={() =>
+                    handleDeleteHistory(
+                      userId as string,
+                      pageName as string,
+                      selectedTab.tabUrlName,
+                      history.historyName,
+                    )
+                  }
                 />
               ))}
             </div>


### PR DESCRIPTION
### FigDiff

## [[Web] Delete History Data](https://www.notion.so/818dfe86e144449aa6c78f0edb9d3cb3?v=7c1403a073984e0b87bf199bd4c1c96a&p=47b9c5e6b4664ec28cdbb6d35cc18e8b&pm=s)

## Todo

- [x] DashBoardPage에서 삭제 버튼을 누르면 figmaProject가 하나 삭제되어야 합니다.
- [x] HistoryPage에서 사이트 이름 삭제 버튼을 누르면 figmaSite가 하나 삭제되어야 합니다.
- [x] HistoryPage에서 history 각각의 삭제 버튼을 누르면 하나의 data가 삭제되어야 합니다.

## Description

- history 관련 삭제버튼을 누르면 서버로 삭제 요청을 보내고 데이터를 삭제하는데, 새로고침을 해야만 삭제된 데이터들이 보여지는 현상이 있어 해당 오류 수정하였습니다.

## Concern (필요시)

- 리뷰 요청 부분 & 컨펌 필요 부분

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
