### PR TITLE
Feat/show diff images

### DIFF
--- a/src/components/HistoryCard.tsx
+++ b/src/components/HistoryCard.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import DeleteButton from "./DeleteButton";
+import ImageModal from "./ImageModal";
 
 interface HistoryCardProps {
   userId: string;
@@ -7,6 +8,7 @@ interface HistoryCardProps {
   tabUrlName: string;
   historyName: string;
   createdAt: string;
+  imageUrls: string[];
   onDelete: () => void;
 }
 
@@ -16,10 +18,22 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
   tabUrlName,
   historyName,
   createdAt,
+  imageUrls,
   onDelete,
 }) => {
+  const [isImageModalOpen, setIsImageModalOpen] = useState<boolean>(false);
+
+  const handleImageModal = () => {
+    setIsImageModalOpen(!isImageModalOpen);
+  };
+
   return (
-    <div className="relative bg-white p-4 shadow rounded-lg m-2 flex-1 max-w-xs">
+    <div
+      onClick={() => {
+        handleImageModal();
+      }}
+      className="relative bg-white p-4 shadow rounded-lg m-2 flex-1 max-w-xs"
+    >
       <div className="flex justify-between items-center">
         <div>
           <DeleteButton
@@ -31,6 +45,13 @@ const HistoryCard: React.FC<HistoryCardProps> = ({
             onDelete={onDelete}
           />
           <h3 className="font-semibold">{createdAt}</h3>
+          {isImageModalOpen && (
+            <ImageModal
+              isOpen={isImageModalOpen}
+              imageUrls={imageUrls}
+              onCancel={handleImageModal}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+import OpacityHandlerModal from "./OpacityHandlerModal";
+
+interface ImageModalProps {
+  isOpen: boolean;
+  imageUrls: string[];
+  onCancel: () => void;
+}
+
+const ImageModal: React.FC<ImageModalProps> = ({
+  isOpen,
+  imageUrls,
+  onCancel,
+}) => {
+  const [screenshotOpacity, setScreenshotOpacity] = useState(0.75);
+  const [figmaOpacity, setFigmaOpacity] = useState(0.25);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50"
+      onClick={onCancel}
+    >
+      <div
+        className="bg-white p-6 rounded-lg shadow-lg relative w-screen h-screen"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          className="absolute top-0 right-0 p-2 text-lg z-50"
+          onClick={onCancel}
+        >
+          X
+        </button>
+        <div className="absolute inset-0 flex justify-center items-center pointer-events-none">
+          <img
+            src={imageUrls[0]}
+            alt="Overlay Image"
+            className="absolute top-0 left-0 w-full h-full object-cover"
+            style={{ opacity: screenshotOpacity }}
+          />
+          <img
+            src={imageUrls[1]}
+            alt="Underlay Image"
+            className="absolute top-0 left-0 w-full h-full object-cover"
+            style={{ opacity: figmaOpacity }}
+          />
+        </div>
+        {isOpen && (
+          <OpacityHandlerModal
+            screenshotOpacity={screenshotOpacity}
+            setScreenshotOpacity={setScreenshotOpacity}
+            figmaOpacity={figmaOpacity}
+            setFigmaOpacity={setFigmaOpacity}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ImageModal;

--- a/src/components/OpacityHandlerModal.tsx
+++ b/src/components/OpacityHandlerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 interface OpacityHandlerModalProps {
   screenshotOpacity: number;
@@ -43,7 +43,7 @@ const OpacityHandlerModal: React.FC<OpacityHandlerModalProps> = ({
     setIsDragging(false);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isDragging) {
       window.addEventListener("mousemove", handleMouseMove);
       window.addEventListener("mouseup", handleMouseUp);

--- a/src/components/OpacityHandlerModal.tsx
+++ b/src/components/OpacityHandlerModal.tsx
@@ -18,13 +18,13 @@ const OpacityHandlerModal: React.FC<OpacityHandlerModalProps> = ({
     y: 0,
   });
   const [isDragging, setIsDragging] = useState(false);
-  const [startPos, setStartPos] = useState({ x: 0, y: 0 });
+  const [startPosition, setStartPosition] = useState({ x: 0, y: 0 });
 
   const handleMouseDown = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ) => {
     setIsDragging(true);
-    setStartPos({
+    setStartPosition({
       x: event.clientX - position.x,
       y: event.clientY - position.y,
     });
@@ -33,8 +33,8 @@ const OpacityHandlerModal: React.FC<OpacityHandlerModalProps> = ({
   const handleMouseMove = (event: MouseEvent) => {
     if (isDragging) {
       setPosition({
-        x: event.clientX - startPos.x,
-        y: event.clientY - startPos.y,
+        x: event.clientX - startPosition.x,
+        y: event.clientY - startPosition.y,
       });
     }
   };

--- a/src/components/OpacityHandlerModal.tsx
+++ b/src/components/OpacityHandlerModal.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+
+interface OpacityHandlerModalProps {
+  screenshotOpacity: number;
+  setScreenshotOpacity: (value: number) => void;
+  figmaOpacity: number;
+  setFigmaOpacity: (value: number) => void;
+}
+
+const OpacityHandlerModal: React.FC<OpacityHandlerModalProps> = ({
+  screenshotOpacity,
+  setScreenshotOpacity,
+  figmaOpacity,
+  setFigmaOpacity,
+}) => {
+  const [position, setPosition] = useState({
+    x: 0,
+    y: 0,
+  });
+  const [isDragging, setIsDragging] = useState(false);
+  const [startPos, setStartPos] = useState({ x: 0, y: 0 });
+
+  const handleMouseDown = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    setIsDragging(true);
+    setStartPos({
+      x: event.clientX - position.x,
+      y: event.clientY - position.y,
+    });
+  };
+
+  const handleMouseMove = (event: MouseEvent) => {
+    if (isDragging) {
+      setPosition({
+        x: event.clientX - startPos.x,
+        y: event.clientY - startPos.y,
+      });
+    }
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  React.useEffect(() => {
+    if (isDragging) {
+      window.addEventListener("mousemove", handleMouseMove);
+      window.addEventListener("mouseup", handleMouseUp);
+    }
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging, handleMouseMove, handleMouseUp]);
+
+  const handleSliderChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    setter: (value: number) => void,
+  ) => {
+    event.stopPropagation();
+    setter(Number(event.target.value) / 100);
+  };
+
+  return (
+    <div
+      className="fixed bg-white p-4 rounded-lg shadow-lg z-50"
+      style={{ top: `${position.y}px`, left: `${position.x}px` }}
+      onMouseDown={handleMouseDown}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={screenshotOpacity * 100}
+            onChange={(event) =>
+              handleSliderChange(event, setScreenshotOpacity)
+            }
+            className="range range-primary"
+            onMouseDown={(event) => event.stopPropagation()}
+          />
+          <div className="text-center">Screenshot Opacity</div>
+        </div>
+        <div>
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={figmaOpacity * 100}
+            onChange={(event) => handleSliderChange(event, setFigmaOpacity)}
+            className="range range-primary"
+            onMouseDown={(event) => event.stopPropagation()}
+          />
+          <div className="text-center">Figma Opacity</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OpacityHandlerModal;

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -8,6 +8,7 @@ interface History {
   _id: string;
   date: string;
   historyName: string;
+  imageUrls: string[];
 }
 
 interface TabUrl {
@@ -204,6 +205,7 @@ const HistoryPage: React.FC = () => {
                   pageName={pageName as string}
                   tabUrlName={selectedTab.tabUrlName}
                   historyName={history.historyName}
+                  imageUrls={history.imageUrls}
                   onDelete={() =>
                     handleDeleteHistory(
                       userId as string,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,7 +4,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
### FigDiff

## [[Web] DiffImageModal](https://www.notion.so/FigDiff-cd08255c47ba43f5bccb6f4579f0d3fa?p=2263a0c1db99454289dd2331b8a43771&pm=s)

## Todo

- [x]  history 클릭 시, 내역 저장시 저장 된 screenshot, figmaimage를 보여줘야 합니다.
- [x]  modal 형식으로 보여줘야 합니다.
- [x]  각 image별 opacity handler가 부착되어야 합니다

## Description

- image modal 의 크기는 스크린 사이즈에 비례합니다.
- opacity handler 고정 문제가 있었는데 해결했습니다.

## PR 전 확인사항

- [x] 가장 최신 브랜치를 pull
- [x] 브랜치명 확인하기
- [x] 코드 컨벤션을 모두 지키기
- [x] reviewer, assignee 확인하기
- [x] conflict가 모두 해결됐는지 확인하기

### 이미지 (필요시)
<img width="1470" alt="스크린샷 2024-07-31 오전 6 07 27" src="https://github.com/user-attachments/assets/a71d7c3a-16ad-420c-b35a-1d4d24e241da">
